### PR TITLE
Må kunne spesifisere java-versjon på bygget

### DIFF
--- a/.github/workflows/gradle-dependency-submission.yaml
+++ b/.github/workflows/gradle-dependency-submission.yaml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: temurin
           java-version: ${{ inputs.java-version }}

--- a/.github/workflows/gradle-dependency-submission.yaml
+++ b/.github/workflows/gradle-dependency-submission.yaml
@@ -2,6 +2,12 @@ name: Gradle Dependency Submission
 
 on:
   workflow_call:
+    inputs:
+      java-version:
+        required: false
+        type: string
+        description: Java version to build with
+        default: "25"
 
 jobs:
   dependency-submission:
@@ -19,5 +25,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ inputs.java-version }}
+          cache: gradle
+          
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # ratchet:gradle/actions/dependency-submission@v6.1.0


### PR DESCRIPTION

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'sokos-skattekort'.
> Could not resolve all artifacts for configuration 'classpath'.
   > Could not resolve io.github.androa.gradle.plugin.avro:plugin:0.0.12.
     Required by:
         buildscript of root project 'sokos-skattekort' > io.github.androa.gradle.plugin.avro:io.github.androa.gradle.plugin.avro.gradle.plugin:0.0.12
      > Dependency requires at least JVM runtime version 21. This build uses a Java 17 JVM.

      https://github.com/navikt/sokos-skattekort/actions/runs/26504224907/job/78254918200#logs